### PR TITLE
Give file tags their own syntax rules

### DIFF
--- a/Odin.sublime-syntax
+++ b/Odin.sublime-syntax
@@ -47,12 +47,6 @@ contexts:
         - meta_scope: comment.line.double-slash.odin
         - match: \n
           pop: true
-    - match: "#[+]"
-      scope: punctuation.definition.comment.odin
-      push:
-        - meta_scope: comment.line.double-slash.odin
-        - match: \n
-          pop: true
 
   keywords:
     - match: \b(import|foreign|package)\b
@@ -82,6 +76,8 @@ contexts:
     - match: \b(cast|transmute|auto_cast)\b
       scope: keyword.function.odin
     - match: '([#]\s*{{identifier}})'
+      scope: keyword.tag.odin
+    - match: '(#[+]\s*[[:alpha:]-][[:alnum:]-]*)'
       scope: keyword.tag.odin
     - match: '(\x40\s*{{identifier}})'
       scope: keyword.tag.odin


### PR DESCRIPTION
This this PR file tags such as `#+build amd64` now look like in this picture. This also fixes an issue where tags such as #optional_ok looked like comments.

![image](https://github.com/user-attachments/assets/8e1d1d0e-7ea4-4ed8-9bc0-fe53a926d295)

Also this makes comments at the end of lines look better:
![image](https://github.com/user-attachments/assets/0c1b9d91-32f7-48b2-abc0-6aed5871db6a)

It supports tags with a dash in them too:
![image](https://github.com/user-attachments/assets/ef5c8017-012e-4c11-b24b-7ffacf33dfb4)

