### PR TITLE
Made Odin.tmLanguage match the changes done in the sublime-syntax file

### DIFF
--- a/Odin.tmLanguage
+++ b/Odin.tmLanguage
@@ -89,7 +89,7 @@
                             </dict>
                         </dict>
                         <key>end</key>
-                        <string>\n</string>
+                        <string>(?=\n)</string>
                         <key>name</key>
                         <string>comment.line.double-slash.odin</string>
                         <key>patterns</key>
@@ -114,7 +114,7 @@
                             </dict>
                         </dict>
                         <key>end</key>
-                        <string>\n</string>
+                        <string>(?=\n)</string>
                         <key>name</key>
                         <string>comment.line.double-slash.odin</string>
                         <key>patterns</key>

--- a/Odin.tmLanguage
+++ b/Odin.tmLanguage
@@ -127,31 +127,6 @@
                             </dict>
                         </array>
                     </dict>
-                    <dict>
-                        <key>begin</key>
-                        <string>#[+]</string>
-                        <key>beginCaptures</key>
-                        <dict>
-                            <key>0</key>
-                            <dict>
-                                <key>name</key>
-                                <string>punctuation.definition.comment.odin</string>
-                            </dict>
-                        </dict>
-                        <key>end</key>
-                        <string>\n</string>
-                        <key>name</key>
-                        <string>comment.line.double-slash.odin</string>
-                        <key>patterns</key>
-                        <array>
-                            <dict>
-                                <key>match</key>
-                                <string>(?&gt;\\\s*\n)</string>
-                                <key>name</key>
-                                <string>punctuation.separator.continuation.odin</string>
-                            </dict>
-                        </array>
-                    </dict>
                 </array>
             </dict>
 
@@ -261,6 +236,12 @@
                     <dict>
                         <key>match</key>
                         <string>([#]\s*\b([[:alpha:]_]+[[:alnum:]_]*)\b)</string>
+                        <key>name</key>
+                        <string>keyword.tag.odin</string>
+                    </dict>
+                    <dict>
+                        <key>match</key>
+                        <string>(#[+]\s*[[:alpha:]-][[:alnum:]-]*)</string>
                         <key>name</key>
                         <string>keyword.tag.odin</string>
                     </dict>


### PR DESCRIPTION
I wasn't aware of the tmLanguage file, so I fixed it up for the `#+build` stuff

Also, while I was at it I fixed this bug that only happens when you use the tmLanguage file:
![image](https://github.com/user-attachments/assets/7997816f-1861-4fe5-a695-b90c76f10496)

It happened because the comment was consuming the newline as opposed  to looking ahead to it.
