### PR TITLE
Comment annotations (TODO, NOTE, IMPORTANT) added to sublime-synthax.

### DIFF
--- a/Odin.sublime-syntax
+++ b/Odin.sublime-syntax
@@ -27,26 +27,40 @@ contexts:
     - match: /\*
       scope: punctuation.definition.comment.odin
       push:
+        - include: comment-annotations
         - meta_scope: comment.block.odin
         - match: \*/
           scope: punctuation.definition.comment.odin
           pop: true
         - include: block-comment
 
-  comments:
-    - include: block-comment
+  line-comments:
     - match: //
       scope: punctuation.definition.comment.odin
       push:
+        - include: comment-annotations
         - meta_scope: comment.line.double-slash.odin
         - match: \n
           pop: true
     - match: "#!"
       scope: punctuation.definition.comment.odin
       push:
+        - include: comment-annotations
         - meta_scope: comment.line.double-slash.odin
         - match: \n
           pop: true
+
+  comment-annotations:
+    - match: (?i)\b(TODO)\b
+      scope: annotation.todo.odin
+    - match: (?i)\b(NOTE)\b
+      scope: annotation.note.odin
+    - match: (?i)\b(IMPORTANT)\b
+      scope: annotation.important.odin
+
+  comments:
+    - include: block-comment
+    - include: line-comments
 
   keywords:
     - match: \b(import|foreign|package)\b


### PR DESCRIPTION
This PR will allow users to have nice TODO, NOTE, IMPORTANT keyword highlights only in comments. (only if they want)

For example: if you add this to your .tmTheme file 
![image](https://github.com/user-attachments/assets/f13465a4-623d-4b5f-a57f-d137efaffd01)

Then you'll able to see TODO comment annotation highlighted in red
![image](https://github.com/user-attachments/assets/a43c2b8c-8bad-4a96-b827-ece1c2aa7ccb)

Basically this PR detects such words in comments and marks them with some ID (for example annotation.todo). In .tmTheme files users can use this ID to set colors to those annotations. 