### PR TITLE
Parenthesis bugfix, better choice of default scopes and re-added some removed stuff

### DIFF
--- a/Odin.sublime-syntax
+++ b/Odin.sublime-syntax
@@ -47,12 +47,6 @@ contexts:
         - meta_scope: comment.line.double-slash.odin
         - match: \n
           pop: true
-    - match: "#[+]"
-      scope: punctuation.definition.comment.odin
-      push:
-        - meta_scope: comment.line.double-slash.odin
-        - match: \n
-          pop: true
 
   keywords:
     - match: \b(import|foreign|package)\b
@@ -89,6 +83,8 @@ contexts:
       scope: keyword.function.odin
     - match: '([#]\s*{{identifier}})'
       scope: keyword.tag.odin
+    - match: '(#\+\s*[[:alpha:]-][[:alnum:]-]*).*'
+      scope: keyword.tag.odin
     - match: '(\x40\s*{{identifier}})'
       scope: keyword.tag.odin
     - match: '(\x40\s*[(]\s*{{identifier}})\s*[)]'
@@ -96,9 +92,9 @@ contexts:
     - match: '@'
       scope: keyword.operator.odin
     - match: '(\(|\)|\{|\}|\[|\]|,|;)'
-      scope: keyword.separator.odin
+      scope: punctuation.separator.odin
     - match: '(\&|\^|\.)'
-      scope: keyword.pointers.odin
+      scope: punctuation.accessor.odin
     # - match: '(\$)'
     #   scope: keyword.generic.odin
 
@@ -106,37 +102,39 @@ contexts:
     - match: '\b({{identifier}})\s*(:)\s*(:)\s*(proc)'
       captures:
         1: meta.function.odin entity.name.function.odin
-        2: keyword.separator.odin
-        3: keyword.separator.odin
+        2: punctuation.separator.odin
+        3: punctuation.separator.odin
         4: storage.type.odin
 
     - match: '\b({{identifier}})\s*(:)\s*(:)\s*([#]force_inline|[#]force_no_inline)\s+(proc)'
       captures:
         1: meta.function.odin entity.name.function.odin
-        2: keyword.separator.odin
-        3: keyword.separator.odin
+        2: punctuation.separator.odin
+        3: punctuation.separator.odin
         4: keyword.control.odin
         5: storage.type.odin
 
-    - match: \b(size_of|align_of|offset_of|type_of)\b\s*\(
+    - match: \b(size_of|align_of|offset_of|type_of)\b\s*(\()
       captures:
         1: keyword.function.odin
-    - match: \b(type_info_of|typeid_of)\b\s*\(
+        2: punctuation.separator.odin
+    - match: \b(type_info_of|typeid_of)\b\s*(\()
       captures:
         1: keyword.function.odin
+        2: punctuation.separator.odin
     - match: (proc)\s*[\(]
       captures:
         1: storage.type.odin
     - match: ({{identifier}})\s*[!]?\s*(\()
       captures:
         1: support.function.odin
-        2: keyword.separator.odin
+        2: punctuation.separator.odin
     
     - match: '\b({{identifier}})\s*(:)\s*(:)\s*(struct|union|enum|bit_set)'
       captures:
         1: meta.type.odin entity.name.type.odin
-        2: keyword.separator.odin
-        3: keyword.separator.odin
+        2: punctuation.separator.odin
+        3: punctuation.separator.odin
         4: storage.type.odin
     
     - match: '\b({{identifier}})\s*(:)\s*(:)\s*([#]\s*type)'
@@ -158,16 +156,16 @@ contexts:
       captures:
         1: storage.type.odin
         2: meta.block.odin punctuation.definition.block.begin.odin 
-        # 2: meta.block.odin keyword.separator.odin
+        # 2: meta.block.odin punctuation.separator.odin
         3: meta.block.odin punctuation.definition.block.end.odin
     - match: '\b(proc)\b'
       scope: storage.type.odin
     - match: (\[)(\d*)(\])(?=[[:alpha:]_])
       scope: meta.brackets.odin 
       captures:
-        1: punctuation.definition.brackets.begin.odin keyword.separator.odin
+        1: punctuation.definition.brackets.begin.odin punctuation.separator.odin
         2: constant.numeric.odin
-        3: punctuation.definition.brackets.end.odin keyword.separator.odin
+        3: punctuation.definition.brackets.end.odin punctuation.separator.odin
     - include: basic-types
 
     - match: '(\$)\s*({{identifier}})'


### PR DESCRIPTION
Fixed some bugs where opening parens of for example `size_of` had wrong color. Also changed the scope of brackets and 'pointers' to something more conventional. Re-added some stuff related to #+build tags that had been accidentally removed.

Regarding the change of some of the scopes: The new colors didn't always look that great in the default theme "marina", which was concerning to me. That's the most common theme and should look good without any extra tweaks.

It looked like this, note how there are too many pink things and there is also a bug with parenthesis after `size_of`
![image](https://github.com/user-attachments/assets/0ac6206e-ec3f-4075-80a0-cbc9ca3b5917)

Now it looks like this:
![image](https://github.com/user-attachments/assets/9f48778a-7339-4291-b33f-adf377fd9a33)

This was fixed by using scope `punctuation.separator.odin` instead of `keyword.separator.odin`. So you can override that scope to give it a different color. The bug was fixed by changing a few special rules for `size_of` etc.

Also note that instead of `keyword.pointers.odin` I changed it to `punctuation.accessor.odin`, which is a more conventional scope. This separate scope is a bit problematic, as `&` will look wrong when used a bit-wise operator. But we can fix that later. In order to fix those things properly we need a much more complicated scoped syntax file.

For future reference I recommend this page when choosing scope names: https://www.sublimetext.com/docs/scope_naming.html